### PR TITLE
feat: Use Vulkan renderer to resolve issue with inverted colors in video

### DIFF
--- a/pe.mk
+++ b/pe.mk
@@ -14,4 +14,6 @@ TARGET_HAS_FUSEBLK_SEPOLICY_ON_VENDOR := true
 TARGET_DISABLE_BLUETOOTH_LE_READ_BUFFER_SIZE_V2 := true
 
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
-    ro.system.ota.json_url=https://raw.githubusercontent.com/ponces/treble_build_pe/thirteen-plus/ota.json
+    ro.system.ota.json_url=https://raw.githubusercontent.com/ponces/treble_build_pe/thirteen-plus/ota.json \
+    ro.hwui.use_vulkan=true \
+    debug.hwui.renderer=skiavk


### PR DESCRIPTION
There's an issue on some devices while playing online videos (YouTube, Vimeo, etc.) or e.g. VLC: the colors are sort-of inverted.

The temp workaround is to use Settings -> Display -> Colors -> Natural or in fact any value except "Boosted". But when using PiP mode for YT or VLC the image in floating window remains inverted.

Here's the example of what I'm talking about (original video can be found [here](https://youtu.be/4WXs3sKu41I))

![photo_2023-03-28 02 22 12](https://user-images.githubusercontent.com/5096148/228088626-59f46b20-e8d4-4d4a-a43c-44eaf038e225.jpeg)

![photo_2023-03-28 02 29 38](https://user-images.githubusercontent.com/5096148/228089508-ebe2b75e-a11e-439b-ae9f-fc85fb05d51b.jpeg)

